### PR TITLE
Fix leaf detection in ReflectionKvCollector

### DIFF
--- a/src/main/java/com/example/metaguard/core/ReflectionKvCollector.java
+++ b/src/main/java/com/example/metaguard/core/ReflectionKvCollector.java
@@ -10,7 +10,16 @@ import java.util.*;
 public class ReflectionKvCollector implements KvCollector {
 
     private static final Set<Class<?>> LEAF = Collections.unmodifiableSet(
-            new HashSet<Class<?>>(Arrays.asList(String.class, Number.class, Boolean.class)));
+            new HashSet<Class<?>>(Arrays.asList(String.class, Boolean.class)));
+
+    private static boolean isLeaf(Object obj) {
+        if (obj == null) return true;
+        Class<?> clazz = obj.getClass();
+        return LEAF.contains(clazz)
+                || clazz.isPrimitive()
+                || Number.class.isAssignableFrom(clazz)
+                || clazz.equals(Character.class);
+    }
 
     @Override
     public Map<String, String> collect(Object root) {
@@ -26,7 +35,7 @@ public class ReflectionKvCollector implements KvCollector {
             if (obj == null) {
                 continue;
             }
-            if (LEAF.contains(obj.getClass())) {
+            if (isLeaf(obj)) {
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- broaden leaf detection logic so wrapper types aren't inspected

## Testing
- `mvn -q test` *(fails: dependencies missing due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6885fb957b108324b7c9951a726128ca